### PR TITLE
Fix 403 responses in admin handlers

### DIFF
--- a/admin/class-my-feedback-plugin-admin.php
+++ b/admin/class-my-feedback-plugin-admin.php
@@ -345,7 +345,11 @@ class My_Feedback_Plugin_Admin {
      */
     public function handle_export_csv() {
         if (!current_user_can('manage_options')) {
-            wp_die(__('Du hast keine Berechtigung, dies zu tun.'), 403);
+            wp_die(
+                __('Du hast keine Berechtigung, dies zu tun.'),
+                '',
+                array('response' => 403)
+            );
         }
         check_admin_referer('feedback_voting_export_csv_action');
 
@@ -400,7 +404,11 @@ class My_Feedback_Plugin_Admin {
      */
     public function handle_delete_all() {
         if (!current_user_can('manage_options')) {
-            wp_die(__('Du hast keine Berechtigung, dies zu tun.'), 403);
+            wp_die(
+                __('Du hast keine Berechtigung, dies zu tun.'),
+                '',
+                array('response' => 403)
+            );
         }
         check_admin_referer('feedback_voting_delete_all_action');
 

--- a/feedback-voting.php
+++ b/feedback-voting.php
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('FEEDBACK_VOTING_VERSION', '1.2.4');
+define('FEEDBACK_VOTING_VERSION', '1.2.6');
 define('FEEDBACK_VOTING_DB_VERSION', '1.0.1');
 define('FEEDBACK_VOTING_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('FEEDBACK_VOTING_PLUGIN_URL', plugin_dir_url(__FILE__));


### PR DESCRIPTION
## Summary
- return proper HTTP status in admin handlers
- sync plugin version constant with plugin header

## Testing
- `php -l admin/class-my-feedback-plugin-admin.php`
- `php -l feedback-voting.php`


------
https://chatgpt.com/codex/tasks/task_e_683f9d596e1c8325a15d62f4ade4b101