### PR TITLE
Add PHPUnit tests for vote insert/update

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Plugin Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/VoteAjaxTest.php
+++ b/tests/VoteAjaxTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Tests for AJAX voting.
+ */
+class Vote_Ajax_Test extends WP_Ajax_UnitTestCase {
+    public function set_up() : void {
+        parent::set_up();
+        // Ensure a user is logged in.
+        $user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+        wp_set_current_user( $user_id );
+    }
+
+    public function test_insert_vote_when_no_vote_id() {
+        $_POST = [
+            'question' => 'Did you like it?',
+            'vote'     => 'yes',
+            'feedback' => '',
+            'post_id'  => 1,
+            'security' => wp_create_nonce( 'feedback_nonce_action' ),
+        ];
+
+        try {
+            $this->_handleAjax( 'my_feedback_plugin_vote' );
+        } catch ( WPAjaxDieContinueException $e ) {}
+
+        $response = json_decode( $this->_last_response, true );
+        $this->assertTrue( $response['success'] );
+        $this->assertNotEmpty( $response['data']['vote_id'] );
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'feedback_votes';
+        $stored = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $table WHERE id = %d", $response['data']['vote_id'] ) );
+        $this->assertSame( 'Did you like it?', $stored->question );
+        $this->assertSame( 'yes', $stored->vote );
+    }
+
+    public function test_update_vote_when_vote_id_provided() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'feedback_votes';
+
+        $wpdb->insert( $table, [
+            'question'      => 'Q',
+            'vote'          => 'no',
+            'feedback_text' => '',
+            'post_id'       => 2,
+            'created_at'    => current_time( 'mysql' ),
+        ] );
+        $vote_id = $wpdb->insert_id;
+
+        $_POST = [
+            'vote_id'  => $vote_id,
+            'feedback' => 'Updated text',
+            'security' => wp_create_nonce( 'feedback_nonce_action' ),
+        ];
+
+        try {
+            $this->_handleAjax( 'my_feedback_plugin_vote' );
+        } catch ( WPAjaxDieContinueException $e ) {}
+
+        $response = json_decode( $this->_last_response, true );
+        $this->assertTrue( $response['success'] );
+        $this->assertSame( $vote_id, $response['data']['vote_id'] );
+
+        $updated = $wpdb->get_var( $wpdb->prepare( "SELECT feedback_text FROM $table WHERE id=%d", $vote_id ) );
+        $this->assertSame( 'Updated text', $updated );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+    $_tests_dir = '/tmp/wordpress-develop/tests/phpunit';
+}
+
+define( 'WP_TESTS_CONFIG_FILE_PATH', __DIR__ . '/wp-tests-config.php' );
+
+require_once $_tests_dir . '/includes/functions.php';
+
+function _manually_load_plugin() {
+    require dirname( __DIR__ ) . '/feedback-voting.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/wp-tests-config.php
+++ b/tests/wp-tests-config.php
@@ -1,0 +1,18 @@
+<?php
+define( 'ABSPATH', '/tmp/wordpress-develop/src/' );
+define( 'WP_DEBUG', true );
+
+define( 'DB_NAME', 'wptests' );
+define( 'DB_USER', 'root' );
+define( 'DB_PASSWORD', '' );
+define( 'DB_HOST', 'localhost' );
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_COLLATE', '' );
+
+$table_prefix = 'wptests_';
+
+define( 'WP_TESTS_DOMAIN', 'example.org' );
+define( 'WP_TESTS_EMAIL', 'admin@example.org' );
+define( 'WP_TESTS_TITLE', 'Test Blog' );
+
+define( 'WP_PHP_BINARY', 'php' );


### PR DESCRIPTION
## Summary
- set up phpunit configuration and bootstrap for WP tests
- add `wp-tests-config.php` for mysql connection to WP test suite
- add AJAX test verifying vote insert and update logic

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_683fa097c19c832582a2997a31f42824