### PR TITLE
Fix missing i18n initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 # Ignoriere alle .bat-Dateien
 *.bat
 output.txt
+
+phpunit
+languages/*.mo

--- a/feedback-voting.php
+++ b/feedback-voting.php
@@ -26,6 +26,7 @@ register_activation_hook(__FILE__, array('My_Feedback_Plugin_DB_Manager', 'activ
 register_deactivation_hook(__FILE__, array('My_Feedback_Plugin_DB_Manager', 'deactivate'));
 
 function feedback_voting_init() {
+    load_plugin_textdomain('feedback-voting', false, dirname(plugin_basename(__FILE__)) . '/languages');
     My_Feedback_Plugin_DB_Manager::maybe_update_db();
     new My_Feedback_Plugin_Admin();
     new My_Feedback_Plugin_Shortcode();

--- a/languages/readme.txt
+++ b/languages/readme.txt
@@ -1,0 +1,1 @@
+Translation files go here.


### PR DESCRIPTION
## Summary
- load the plugin text domain during initialization so translation files are recognized
- ignore phpunit binary and language `.mo` files
- add placeholder language directory

## Testing
- `php -l feedback-voting.php`
- `./phpunit -c phpunit.xml` *(fails: PHPUnit Polyfills missing)*

------
https://chatgpt.com/codex/tasks/task_e_683fa5632b488325a6958d7009127cb3