### PR TITLE
Fix default colors in admin settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Feedback Voting Plugin
+
+This plugin adds a simple voting system with optional feedback field. PHPUnit tests require the WordPress testing framework.
+
+## Installing the WordPress testing framework
+
+Before running the tests, install the WordPress development repository and create the test database:
+
+```bash
+bin/install-wp-tests.sh
+```
+
+This clones `wordpress-develop` into `/tmp/wordpress-develop`, creates the `wptests` database (if MySQL is available) and copies the configuration file.
+
+## Running tests
+
+Once the framework is installed, run:
+
+```bash
+phpunit -c phpunit.xml
+```
+

--- a/admin/class-my-feedback-plugin-admin.php
+++ b/admin/class-my-feedback-plugin-admin.php
@@ -94,7 +94,11 @@ class My_Feedback_Plugin_Admin {
             array($this, 'color_field_render'),
             'feedback_voting_settings',
             'feedback_voting_settings_section',
-            array('option_name' => 'feedback_voting_primary_color', 'label_for' => 'feedback_voting_primary_color')
+            array(
+                'option_name' => 'feedback_voting_primary_color',
+                'label_for'   => 'feedback_voting_primary_color',
+                'default'     => '#0073aa',
+            )
         );
         add_settings_field(
             'feedback_voting_button_color',
@@ -102,7 +106,11 @@ class My_Feedback_Plugin_Admin {
             array($this, 'color_field_render'),
             'feedback_voting_settings',
             'feedback_voting_settings_section',
-            array('option_name' => 'feedback_voting_button_color', 'label_for' => 'feedback_voting_button_color')
+            array(
+                'option_name' => 'feedback_voting_button_color',
+                'label_for'   => 'feedback_voting_button_color',
+                'default'     => '#0073aa',
+            )
         );
         add_settings_field(
             'feedback_voting_button_hover_color',
@@ -110,7 +118,11 @@ class My_Feedback_Plugin_Admin {
             array($this, 'color_field_render'),
             'feedback_voting_settings',
             'feedback_voting_settings_section',
-            array('option_name' => 'feedback_voting_button_hover_color', 'label_for' => 'feedback_voting_button_hover_color')
+            array(
+                'option_name' => 'feedback_voting_button_hover_color',
+                'label_for'   => 'feedback_voting_button_hover_color',
+                'default'     => '#005b8d',
+            )
         );
         add_settings_field(
             'feedback_voting_border_radius',
@@ -134,14 +146,17 @@ class My_Feedback_Plugin_Admin {
 
     /** Render Color-Picker-Felder */
     public function color_field_render($args) {
-        $option = $args['option_name'];
-        $id     = $args['label_for'];
-        $color  = get_option($option, '');
+        $option  = $args['option_name'];
+        $id      = $args['label_for'];
+        $default = isset($args['default']) ? $args['default'] : '';
+
+        $color = get_option($option, $default);
+
         printf(
             '<input class="feedback-color-field" type="text" id="%1$s" name="%1$s" value="%2$s" data-default-color="%3$s" />',
             esc_attr($id),
             esc_attr($color),
-            esc_attr(get_option($option, ''))
+            esc_attr($default)
         );
     }
 

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Installs the WordPress testing framework.
+# Usage: bin/install-wp-tests.sh [db-name] [db-user] [db-pass] [db-host] [wp-version]
+
+set -euo pipefail
+
+DB_NAME=${1:-wptests}
+DB_USER=${2:-root}
+DB_PASS=${3:-}
+DB_HOST=${4:-localhost}
+WP_VERSION=${5:-trunk}
+
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress-develop}
+WP_TESTS_DIR="$WP_CORE_DIR/tests/phpunit"
+
+if [ ! -d "$WP_CORE_DIR" ]; then
+    echo "Cloning WordPress development repository..."
+    git clone --depth=1 https://github.com/WordPress/wordpress-develop.git "$WP_CORE_DIR"
+fi
+
+# Create the database if possible.
+if command -v mysqladmin >/dev/null; then
+    echo "Creating database $DB_NAME if it does not exist..."
+    mysqladmin create "$DB_NAME" --user="$DB_USER" --password="$DB_PASS" --host="$DB_HOST" 2>/dev/null || true
+else
+    echo "mysqladmin command not found. Please create database '$DB_NAME' manually." >&2
+fi
+
+CONFIG_FILE="$WP_TESTS_DIR/wp-tests-config.php"
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "Copying wp-tests-config.php..."
+    mkdir -p "$WP_TESTS_DIR"
+    cp "$(dirname "$0")/../tests/wp-tests-config.php" "$CONFIG_FILE"
+fi
+
+echo "WordPress test framework installed at $WP_TESTS_DIR"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,6 +6,10 @@ if ( ! $_tests_dir ) {
 
 define( 'WP_TESTS_CONFIG_FILE_PATH', __DIR__ . '/wp-tests-config.php' );
 
+if ( ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
+    define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', '/tmp/PHPUnit-Polyfills' );
+}
+
 require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {


### PR DESCRIPTION
## Summary
- fix color picker defaults so the fallback colors are consistent
- add script to install the WordPress testing framework
- document how to run the tests

## Testing
- `bash bin/install-wp-tests.sh`
- `phpunit -c phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_683fa94012e8832595cc8353afb906cf