### PR TITLE
Add customizable before-text option and working tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ output.txt
 
 phpunit
 languages/*.mo
+.phpunit.result.cache

--- a/admin/class-my-feedback-plugin-admin.php
+++ b/admin/class-my-feedback-plugin-admin.php
@@ -73,6 +73,11 @@ class My_Feedback_Plugin_Admin {
             'sanitize_callback' => 'sanitize_text_field',
             'default'           => '9999px',
         ));
+        register_setting('feedback_voting_settings_group', 'feedback_voting_before_text', array(
+            'type'              => 'string',
+            'sanitize_callback' => 'wp_kses_post',
+            'default'           => __('Helfen Sie uns, was können wir besser machen?', 'feedback-voting'),
+        ));
 
         add_settings_section(
             'feedback_voting_settings_section',
@@ -131,6 +136,13 @@ class My_Feedback_Plugin_Admin {
             'feedback_voting_settings',
             'feedback_voting_settings_section'
         );
+        add_settings_field(
+            'feedback_voting_before_text',
+            __('Text oberhalb des Feedback-Felds', 'feedback-voting'),
+            array($this, 'before_text_render'),
+            'feedback_voting_settings',
+            'feedback_voting_settings_section'
+        );
     }
 
     /** Render Checkbox für Freitext-Feld */
@@ -168,6 +180,15 @@ class My_Feedback_Plugin_Admin {
             esc_attr($value)
         );
         echo '<p class="description">' . __('z.B. "4px", "1rem", "50%"','feedback-voting') . '</p>';
+    }
+
+    /** Render Textarea for label above feedback field */
+    public function before_text_render() {
+        $value = get_option('feedback_voting_before_text', __('Helfen Sie uns, was können wir besser machen?', 'feedback-voting'));
+        printf(
+            '<textarea id="feedback_voting_before_text" name="feedback_voting_before_text" rows="3" class="large-text code">%s</textarea>',
+            esc_textarea($value)
+        );
     }
 
     /** Admin-Dashboard rendern */

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -12,10 +12,16 @@ WP_VERSION=${5:-trunk}
 
 WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress-develop}
 WP_TESTS_DIR="$WP_CORE_DIR/tests/phpunit"
+PHPUNIT_POLYFILLS_DIR="/tmp/PHPUnit-Polyfills"
 
 if [ ! -d "$WP_CORE_DIR" ]; then
     echo "Cloning WordPress development repository..."
     git clone --depth=1 https://github.com/WordPress/wordpress-develop.git "$WP_CORE_DIR"
+fi
+
+if [ ! -d "$PHPUNIT_POLYFILLS_DIR" ]; then
+    echo "Cloning PHPUnit Polyfills library..."
+    git clone --depth=1 https://github.com/Yoast/PHPUnit-Polyfills.git "$PHPUNIT_POLYFILLS_DIR"
 fi
 
 # Create the database if possible.

--- a/feedback-voting.php
+++ b/feedback-voting.php
@@ -3,7 +3,7 @@
 Plugin Name: Feedback Voting
 Plugin URI:  https://vogel-webmarketing.de/feedback-voting/
 Description: Bietet ein einfaches "War diese Antwort hilfreich?" (Ja/Nein) Feedback-Voting
-Version:     1.2.6
+Version:     1.2.8
 Author:      Matthes Vogel
 Text Domain: feedback-voting
 */
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('FEEDBACK_VOTING_VERSION', '1.2.6');
+define('FEEDBACK_VOTING_VERSION', '1.2.8');
 define('FEEDBACK_VOTING_DB_VERSION', '1.0.1');
 define('FEEDBACK_VOTING_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('FEEDBACK_VOTING_PLUGIN_URL', plugin_dir_url(__FILE__));

--- a/includes/class-my-feedback-plugin-shortcode.php
+++ b/includes/class-my-feedback-plugin-shortcode.php
@@ -56,7 +56,7 @@ class My_Feedback_Plugin_Shortcode {
         <!-- Separate Box ohne Rahmen für das "Nein"-Feedback -->
         <div class="feedback-no-text-box">
             <label for="<?php echo esc_attr( $unique_id ); ?>">
-                <?php _e('Helfen Sie uns, was können wir besser machen?', 'feedback-voting'); ?>
+                <?php echo wp_kses_post( get_option( 'feedback_voting_before_text', __( 'Helfen Sie uns, was können wir besser machen?', 'feedback-voting' ) ) ); ?>
             </label>
             <textarea
             class="feedback-no-text"


### PR DESCRIPTION
## Summary
- bump version to 1.2.8
- add `feedback_voting_before_text` option so admins can customize HTML label above feedback textarea
- render textarea on settings page
- sanitize the label with `wp_kses_post` when output
- install PHPUnit Polyfills in test script
- ignore phpunit result cache

## Testing
- `bash bin/install-wp-tests.sh wptests root '' localhost latest`
- `phpunit -c phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_683fb9b875588325ba567b71cff22efd