### PR TITLE
Add width option and dark mode label update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This plugin adds a simple voting system with optional feedback field. PHPUnit tests require the WordPress testing framework.
 
+Since version 1.2.9 you can configure the box width in the admin settings. The label above the feedback field also adapts for dark mode.
+
 ## Installing the WordPress testing framework
 
 Before running the tests, install the WordPress development repository and create the test database:

--- a/admin/class-my-feedback-plugin-admin.php
+++ b/admin/class-my-feedback-plugin-admin.php
@@ -78,6 +78,11 @@ class My_Feedback_Plugin_Admin {
             'sanitize_callback' => 'wp_kses_post',
             'default'           => __('Helfen Sie uns, was können wir besser machen?', 'feedback-voting'),
         ));
+        register_setting('feedback_voting_settings_group', 'feedback_voting_box_width', array(
+            'type'              => 'integer',
+            'sanitize_callback' => 'absint',
+            'default'           => 100,
+        ));
 
         add_settings_section(
             'feedback_voting_settings_section',
@@ -143,6 +148,13 @@ class My_Feedback_Plugin_Admin {
             'feedback_voting_settings',
             'feedback_voting_settings_section'
         );
+        add_settings_field(
+            'feedback_voting_box_width',
+            __('Box-Breite (%)', 'feedback-voting'),
+            array($this, 'box_width_render'),
+            'feedback_voting_settings',
+            'feedback_voting_settings_section'
+        );
     }
 
     /** Render Checkbox für Freitext-Feld */
@@ -188,6 +200,15 @@ class My_Feedback_Plugin_Admin {
         printf(
             '<textarea id="feedback_voting_before_text" name="feedback_voting_before_text" rows="3" class="large-text code">%s</textarea>',
             esc_textarea($value)
+        );
+    }
+
+    /** Render Input for box width percentage */
+    public function box_width_render() {
+        $value = get_option('feedback_voting_box_width', 100);
+        printf(
+            '<input type="number" id="feedback_voting_box_width" name="feedback_voting_box_width" value="%d" min="10" max="100" />%%',
+            intval($value)
         );
     }
 

--- a/css/style.css
+++ b/css/style.css
@@ -9,6 +9,7 @@
   font-size: 1rem;
   padding: 0.5rem 1rem;
   margin-bottom: 1.5rem;
+  width: var(--fv-box-width, 100%);
 }
 
 .feedback-voting-top-row {
@@ -46,6 +47,7 @@
   padding: 1rem 0;
   border: none;
   display: none;
+  width: var(--fv-box-width, 100%);
 }
 
 .feedback-no-text-box label {
@@ -53,6 +55,12 @@
   margin-bottom: 0.5rem;
   font-weight: 600;
   color: #1b1c1c;
+}
+
+@media (prefers-color-scheme: dark) {
+  .feedback-no-text-box label {
+    color: #f1f1f1;
+  }
 }
 
 .feedback-no-text-box textarea {

--- a/feedback-voting.php
+++ b/feedback-voting.php
@@ -3,7 +3,7 @@
 Plugin Name: Feedback Voting
 Plugin URI:  https://vogel-webmarketing.de/feedback-voting/
 Description: Bietet ein einfaches "War diese Antwort hilfreich?" (Ja/Nein) Feedback-Voting
-Version:     1.2.8
+Version:     1.2.9
 Author:      Matthes Vogel
 Text Domain: feedback-voting
 */
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('FEEDBACK_VOTING_VERSION', '1.2.8');
+define('FEEDBACK_VOTING_VERSION', '1.2.9');
 define('FEEDBACK_VOTING_DB_VERSION', '1.0.1');
 define('FEEDBACK_VOTING_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('FEEDBACK_VOTING_PLUGIN_URL', plugin_dir_url(__FILE__));
@@ -57,12 +57,14 @@ function feedback_voting_enqueue_scripts() {
     $button_color      = get_option('feedback_voting_button_color', $primary_color);
     $hover_color       = get_option('feedback_voting_button_hover_color', '#005b8d');
     $border_radius     = get_option('feedback_voting_border_radius', '9999px');
+    $box_width         = absint(get_option('feedback_voting_box_width', 100));
     $custom_css = "
         :root {
             --fv-primary: {$primary_color};
             --fv-button-color: {$button_color};
             --fv-button-hover-color: {$hover_color};
             --fv-border-radius: {$border_radius};
+            --fv-box-width: {$box_width}%;
         }
     ";
     wp_add_inline_style('feedback-voting-style', $custom_css);


### PR DESCRIPTION
## Summary
- allow setting box width in plugin options
- ensure feedback label visible in dark mode
- note width option in documentation
- bump version to 1.2.9

## Testing
- `phpunit -c phpunit.xml` *(fails: missing MySQL setup)*

------
https://chatgpt.com/codex/tasks/task_e_683fe9a39c7883258e2f58dc105fc14e