### PR TITLE
Improve feedback label readability in dark mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,6 +24,12 @@
   color: #1b1c1c;
 }
 
+@media (prefers-color-scheme: dark) {
+  .feedback-question {
+    color: #f1f1f1;
+  }
+}
+
 .feedback-button {
   background-color: var(--fv-button-color, var(--fv-primary, #0073aa));
   color: #fff;


### PR DESCRIPTION
## Summary
- enhance CSS so the question label is readable when dark mode is enabled

## Testing
- `phpunit -c phpunit.xml` *(fails: missing WordPress test framework)*

------
https://chatgpt.com/codex/tasks/task_e_68400c6fc0f08325bf86933f22b69d91