### PR TITLE
Fix label readability in dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin adds a simple voting system with optional feedback field. PHPUnit tests require the WordPress testing framework.
 
-Since version 1.2.9 you can configure the box width in the admin settings. The label above the feedback field also adapts for dark mode.
+Since version 1.2.11 you can configure the box width in the admin settings. All labels are now readable in dark mode.
 
 ## Installing the WordPress testing framework
 

--- a/css/style.css
+++ b/css/style.css
@@ -25,7 +25,9 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .feedback-question {
+  .feedback-question,
+  .feedback-no-text-box label,
+  .feedback-thankyou {
     color: #f1f1f1;
   }
 }
@@ -61,12 +63,6 @@
   margin-bottom: 0.5rem;
   font-weight: 600;
   color: #1b1c1c;
-}
-
-@media (prefers-color-scheme: dark) {
-  .feedback-no-text-box label {
-    color: #f1f1f1;
-  }
 }
 
 .feedback-no-text-box textarea {

--- a/feedback-voting.php
+++ b/feedback-voting.php
@@ -3,7 +3,7 @@
 Plugin Name: Feedback Voting
 Plugin URI:  https://vogel-webmarketing.de/feedback-voting/
 Description: Bietet ein einfaches "War diese Antwort hilfreich?" (Ja/Nein) Feedback-Voting
-Version:     1.2.10
+Version:     1.2.11
 Author:      Matthes Vogel
 Text Domain: feedback-voting
 */
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('FEEDBACK_VOTING_VERSION', '1.2.10');
+define('FEEDBACK_VOTING_VERSION', '1.2.11');
 define('FEEDBACK_VOTING_DB_VERSION', '1.0.1');
 define('FEEDBACK_VOTING_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('FEEDBACK_VOTING_PLUGIN_URL', plugin_dir_url(__FILE__));


### PR DESCRIPTION
## Summary
- ensure all label text is readable in dark mode
- bump plugin version to 1.2.11
- update README

## Testing
- `phpunit -c phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684019b375048325a6234aa40b19be5a