### PR TITLE
Fix dark mode labels

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,14 +24,6 @@
   color: #1b1c1c;
 }
 
-@media (prefers-color-scheme: dark) {
-  .feedback-question,
-  .feedback-no-text-box label,
-  .feedback-thankyou {
-    color: #f1f1f1;
-  }
-}
-
 .feedback-button {
   background-color: var(--fv-button-color, var(--fv-primary, #0073aa));
   color: #fff;
@@ -86,6 +78,14 @@
   margin: 0 0 1rem 0;
 }
 
+@media (prefers-color-scheme: dark) {
+  .feedback-question,
+  .feedback-no-text-box label,
+  .feedback-thankyou {
+    color: #f1f1f1;
+  }
+}
+
 @media only screen and (max-width: 600px) {
   .feedback-button.feedback-yes .button-text,
   .feedback-button.feedback-no .button-text {
@@ -97,3 +97,4 @@
     font-size: 16px;
   }
 }
+


### PR DESCRIPTION
## Summary
- adjust CSS so dark mode colors override base styles

## Testing
- `phpunit -c phpunit.xml` *(fails: missing WordPress test framework)*

------
https://chatgpt.com/codex/tasks/task_e_68401b5b41948325adcca41b5ee941cd