### PR TITLE
Fix border color in dark mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -79,6 +79,9 @@
 }
 
 @media (prefers-color-scheme: dark) {
+  .feedback-voting-container {
+    border-color: var(--fv-primary, #0073aa);
+  }
   .feedback-question,
   .feedback-no-text-box label,
   .feedback-thankyou {


### PR DESCRIPTION
## Summary
- ensure feedback voting frame keeps its saved border color in dark mode

## Testing
- `bash bin/install-wp-tests.sh`
- `phpunit -c phpunit.xml` *(fails: mysqli_real_connect(): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68401d508a808325a31a609d6aafdf4f