### PR TITLE
Fix border color in dark mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -79,10 +79,13 @@
 }
 
 @media (prefers-color-scheme: dark) {
+  .feedback-voting-container {
+    border-color: var(--fv-primary, #0073aa);
+  }
   .feedback-question,
   .feedback-no-text-box label,
   .feedback-thankyou {
-    color: #f1f1f1;
+    color: #f1f1f1 !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure feedback voting frame keeps its saved border color in dark mode
- force label text to lighten in dark mode for better readability

## Testing
- `bash bin/install-wp-tests.sh`
- `phpunit -c phpunit.xml` *(fails: VoteAjaxTest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401d508a808325a31a609d6aafdf4f