### PR TITLE
Ensure dark mode retains border color

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -80,12 +80,14 @@
 
 @media (prefers-color-scheme: dark) {
   .feedback-voting-container {
-    border-color: var(--fv-primary, #0073aa);
+    /* Maintain the same border color in dark mode */
+    border-color: var(--fv-primary, #0073aa) !important;
   }
   .feedback-question,
   .feedback-no-text-box label,
   .feedback-thankyou {
-    color: #f1f1f1 !important;
+    /* Use bright white text so labels stay readable */
+    color: #ffffff !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the feedback voting border color consistent in dark mode
- make labels bright white in dark mode

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68406563c3608325bccc04a17c25b99b