### PR TITLE
Implement customizable rounding and button labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin adds a simple voting system with optional feedback field. PHPUnit tests require the WordPress testing framework.
 
-Since version 1.3.1 you can display multiple `[feedback_score]` shortcodes on one page. The shortcode was introduced in 1.3.0. Version 1.2.11 added configurable box width and improved dark mode labels.
+Since version 1.3.2 you can customize button labels and the border radius for the feedback and score boxes. Version 1.3.1 allowed multiple `[feedback_score]` shortcodes on one page. The shortcode was introduced in 1.3.0. Version 1.2.11 added configurable box width and improved dark mode labels.
 
 ## Installing the WordPress testing framework
 

--- a/admin/class-my-feedback-plugin-admin.php
+++ b/admin/class-my-feedback-plugin-admin.php
@@ -73,6 +73,31 @@ class My_Feedback_Plugin_Admin {
             'sanitize_callback' => 'sanitize_text_field',
             'default'           => '9999px',
         ));
+        register_setting('feedback_voting_settings_group', 'feedback_voting_yes_label', array(
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default'           => __('Ja, war sie', 'feedback-voting'),
+        ));
+        register_setting('feedback_voting_settings_group', 'feedback_voting_no_label', array(
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default'           => __('Nein, leider nicht', 'feedback-voting'),
+        ));
+        register_setting('feedback_voting_settings_group', 'feedback_voting_container_radius', array(
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default'           => '6rem',
+        ));
+        register_setting('feedback_voting_settings_group', 'feedback_voting_score_radius', array(
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default'           => '6px',
+        ));
+        register_setting('feedback_voting_settings_group', 'feedback_voting_submit_label', array(
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            'default'           => __('Feedback senden', 'feedback-voting'),
+        ));
         register_setting('feedback_voting_settings_group', 'feedback_voting_before_text', array(
             'type'              => 'string',
             'sanitize_callback' => 'wp_kses_post',
@@ -167,6 +192,41 @@ class My_Feedback_Plugin_Admin {
             'feedback_voting_settings',
             'feedback_voting_settings_section'
         );
+        add_settings_field(
+            'feedback_voting_yes_label',
+            __('Text Button "Ja"', 'feedback-voting'),
+            array($this, 'yes_label_render'),
+            'feedback_voting_settings',
+            'feedback_voting_settings_section'
+        );
+        add_settings_field(
+            'feedback_voting_no_label',
+            __('Text Button "Nein"', 'feedback-voting'),
+            array($this, 'no_label_render'),
+            'feedback_voting_settings',
+            'feedback_voting_settings_section'
+        );
+        add_settings_field(
+            'feedback_voting_container_radius',
+            __('Box-Rundungen (CSS)', 'feedback-voting'),
+            array($this, 'container_radius_render'),
+            'feedback_voting_settings',
+            'feedback_voting_settings_section'
+        );
+        add_settings_field(
+            'feedback_voting_score_radius',
+            __('Score-Box-Rundungen (CSS)', 'feedback-voting'),
+            array($this, 'score_radius_render'),
+            'feedback_voting_settings',
+            'feedback_voting_settings_section'
+        );
+        add_settings_field(
+            'feedback_voting_submit_label',
+            __('Beschriftung Feedback-Button', 'feedback-voting'),
+            array($this, 'submit_label_render'),
+            'feedback_voting_settings',
+            'feedback_voting_settings_section'
+        );
     }
 
     /** Render Checkbox für Freitext-Feld */
@@ -229,6 +289,51 @@ class My_Feedback_Plugin_Admin {
         $value = get_option('feedback_voting_score_label', __('Euer Score', 'feedback-voting'));
         printf(
             '<input type="text" id="feedback_voting_score_label" name="feedback_voting_score_label" value="%s" class="regular-text" />',
+            esc_attr($value)
+        );
+    }
+
+    /** Render input for the yes button label */
+    public function yes_label_render() {
+        $value = get_option('feedback_voting_yes_label', __('Ja, war sie', 'feedback-voting'));
+        printf(
+            '<input type="text" id="feedback_voting_yes_label" name="feedback_voting_yes_label" value="%s" class="regular-text" />',
+            esc_attr($value)
+        );
+    }
+
+    /** Render input for the no button label */
+    public function no_label_render() {
+        $value = get_option('feedback_voting_no_label', __('Nein, leider nicht', 'feedback-voting'));
+        printf(
+            '<input type="text" id="feedback_voting_no_label" name="feedback_voting_no_label" value="%s" class="regular-text" />',
+            esc_attr($value)
+        );
+    }
+
+    /** Render input for feedback box radius */
+    public function container_radius_render() {
+        $value = get_option('feedback_voting_container_radius', '6rem');
+        printf(
+            '<input type="text" id="feedback_voting_container_radius" name="feedback_voting_container_radius" value="%s" />',
+            esc_attr($value)
+        );
+    }
+
+    /** Render input for score box radius */
+    public function score_radius_render() {
+        $value = get_option('feedback_voting_score_radius', '6px');
+        printf(
+            '<input type="text" id="feedback_voting_score_radius" name="feedback_voting_score_radius" value="%s" />',
+            esc_attr($value)
+        );
+    }
+
+    /** Render input for submit button label */
+    public function submit_label_render() {
+        $value = get_option('feedback_voting_submit_label', __('Feedback senden', 'feedback-voting'));
+        printf(
+            '<input type="text" id="feedback_voting_submit_label" name="feedback_voting_submit_label" value="%s" class="regular-text" />',
             esc_attr($value)
         );
     }

--- a/css/style.css
+++ b/css/style.css
@@ -5,7 +5,7 @@
 .feedback-voting-container {
   display: inline-block;
   border: 1.5px solid var(--fv-primary, #0073aa);
-  border-radius: 6rem;
+  border-radius: var(--fv-container-radius, 6rem);
   font-size: 1rem;
   padding: 0.5rem 1rem;
   margin-bottom: 1.5rem;
@@ -112,7 +112,7 @@
   width: 80px;
   height: 80px;
   border: 2px solid var(--fv-primary, #0073aa);
-  border-radius: 6px;
+  border-radius: var(--fv-score-radius, 6px);
   margin-bottom: 1rem;
   font-size: 1.5rem;
 }

--- a/feedback-voting.php
+++ b/feedback-voting.php
@@ -3,7 +3,7 @@
 Plugin Name: Feedback Voting
 Plugin URI:  https://vogel-webmarketing.de/feedback-voting/
 Description: Bietet ein einfaches "War diese Antwort hilfreich?" (Ja/Nein) Feedback-Voting
-Version:     1.3.1
+Version:     1.3.2
 Author:      Matthes Vogel
 Text Domain: feedback-voting
 */
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('FEEDBACK_VOTING_VERSION', '1.3.1');
+define('FEEDBACK_VOTING_VERSION', '1.3.2');
 define('FEEDBACK_VOTING_DB_VERSION', '1.0.1');
 define('FEEDBACK_VOTING_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('FEEDBACK_VOTING_PLUGIN_URL', plugin_dir_url(__FILE__));
@@ -57,6 +57,8 @@ function feedback_voting_enqueue_scripts() {
     $button_color      = get_option('feedback_voting_button_color', $primary_color);
     $hover_color       = get_option('feedback_voting_button_hover_color', '#005b8d');
     $border_radius     = get_option('feedback_voting_border_radius', '9999px');
+    $container_radius  = get_option('feedback_voting_container_radius', '6rem');
+    $score_radius      = get_option('feedback_voting_score_radius', '6px');
     $box_width         = absint(get_option('feedback_voting_box_width', 100));
     $custom_css = "
         :root {
@@ -64,6 +66,8 @@ function feedback_voting_enqueue_scripts() {
             --fv-button-color: {$button_color};
             --fv-button-hover-color: {$hover_color};
             --fv-border-radius: {$border_radius};
+            --fv-container-radius: {$container_radius};
+            --fv-score-radius: {$score_radius};
             --fv-box-width: {$box_width}%;
         }
     ";

--- a/includes/class-my-feedback-plugin-shortcode.php
+++ b/includes/class-my-feedback-plugin-shortcode.php
@@ -30,6 +30,10 @@ class My_Feedback_Plugin_Shortcode {
         // Generate unique ID for textarea and label to avoid conflicts
         $unique_id = 'feedback-no-text-' . uniqid();
 
+        $yes_label    = get_option('feedback_voting_yes_label', __('Ja, war sie', 'feedback-voting'));
+        $no_label     = get_option('feedback_voting_no_label', __('Nein, leider nicht', 'feedback-voting'));
+        $submit_label = get_option('feedback_voting_submit_label', __('Feedback senden', 'feedback-voting'));
+
         ob_start();
         ?>
         <!-- Hauptcontainer mit Rahmen -->
@@ -43,13 +47,13 @@ class My_Feedback_Plugin_Shortcode {
                 <!-- Daumen hoch -->
                 <button class="feedback-button feedback-yes" data-vote="yes">
                     <span class="dashicons dashicons-thumbs-up"></span>
-                    <span class="button-text"><?php _e('Ja, war sie', 'feedback-voting'); ?></span>
+                    <span class="button-text"><?php echo esc_html($yes_label); ?></span>
                 </button>
 
                 <!-- Daumen runter -->
                 <button class="feedback-button feedback-no" data-vote="no">
                     <span class="dashicons dashicons-thumbs-down"></span>
-                    <span class="button-text"><?php _e('Nein, leider nicht', 'feedback-voting'); ?></span>
+                    <span class="button-text"><?php echo esc_html($no_label); ?></span>
                 </button>
             </div>
         </div>
@@ -67,7 +71,7 @@ class My_Feedback_Plugin_Shortcode {
             ></textarea>
 
             <button class="feedback-button feedback-submit-no">
-                <span class="button-text"><?php _e('Feedback senden', 'feedback-voting'); ?></span>
+                <span class="button-text"><?php echo esc_html($submit_label); ?></span>
             </button>
         </div>
         <?php


### PR DESCRIPTION
## Summary
- allow configuring border radius for feedback and score boxes
- make all button texts editable
- inject CSS variables for new settings
- bump to version 1.3.2 and document changes

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68439f1a7b448325939bbf505f3547e0