### PR TITLE
Bump version and show max score

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin adds a simple voting system with optional feedback field. PHPUnit tests require the WordPress testing framework.
 
-Since version 1.3.2 you can customize button labels and the border radius for the feedback and score boxes. Version 1.3.1 allowed multiple `[feedback_score]` shortcodes on one page. The shortcode was introduced in 1.3.0. Version 1.2.11 added configurable box width and improved dark mode labels. Version 1.3.3 introduced layout options for the score box including alignment and text wrapping. The latest update adds padding inside the score box and centers the text.
+Since version 1.3.2 you can customize button labels and the border radius for the feedback and score boxes. Version 1.3.1 allowed multiple `[feedback_score]` shortcodes on one page. The shortcode was introduced in 1.3.0. Version 1.2.11 added configurable box width and improved dark mode labels. Version 1.3.3 introduced layout options for the score box including alignment and text wrapping. Version 1.3.4 added padding inside the score box and centered the text. The latest update ensures consistent spacing on all sides and shows the score as "x/5".
 
 ## Installing the WordPress testing framework
 

--- a/css/style.css
+++ b/css/style.css
@@ -109,9 +109,11 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 0.25rem;
   box-sizing: border-box;
   padding: 0.5rem;
   text-align: center;
+  line-height: 1;
   width: 80px;
   height: 80px;
   border: 2px solid var(--fv-primary, #0073aa);
@@ -120,8 +122,11 @@
   font-size: 1.5rem;
 }
 
-.feedback-score-box small {
+.feedback-score-box small,
+.feedback-score-box .feedback-score-value {
   font-size: 0.75rem;
+  line-height: 1;
+  margin: 0;
 }
 
 /* Alignment helpers for the score box */

--- a/feedback-voting.php
+++ b/feedback-voting.php
@@ -3,7 +3,7 @@
 Plugin Name: Feedback Voting
 Plugin URI:  https://vogel-webmarketing.de/feedback-voting/
 Description: Bietet ein einfaches "War diese Antwort hilfreich?" (Ja/Nein) Feedback-Voting
-Version:     1.3.4
+Version:     1.3.5
 Author:      Matthes Vogel
 Text Domain: feedback-voting
 */
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('FEEDBACK_VOTING_VERSION', '1.3.4');
+define('FEEDBACK_VOTING_VERSION', '1.3.5');
 define('FEEDBACK_VOTING_DB_VERSION', '1.0.1');
 define('FEEDBACK_VOTING_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('FEEDBACK_VOTING_PLUGIN_URL', plugin_dir_url(__FILE__));

--- a/includes/class-my-feedback-plugin-shortcode.php
+++ b/includes/class-my-feedback-plugin-shortcode.php
@@ -131,7 +131,7 @@ class My_Feedback_Plugin_Shortcode {
         ?>
         <div id="<?php echo esc_attr( $unique_id ); ?>" class="<?php echo esc_attr( $class_attr ); ?>">
             <small class="feedback-score-label"><?php echo esc_html($label); ?></small>
-            <span class="feedback-score-value"><?php echo number_format($score, 1); ?></span>
+            <span class="feedback-score-value"><?php echo number_format($score, 1) . '/5'; ?></span>
         </div>
         <?php
         return ob_get_clean();

--- a/tests/ScoreShortcodeTest.php
+++ b/tests/ScoreShortcodeTest.php
@@ -24,7 +24,7 @@ class Score_Shortcode_Test extends WP_UnitTestCase {
         ] );
 
         $output = do_shortcode( '[feedback_score question="Q1" post_id="1"]' );
-        $this->assertStringContainsString( '3.0', $output );
+        $this->assertStringContainsString( '3.0/5', $output );
     }
 
     public function test_multiple_score_shortcodes_on_page() {
@@ -50,8 +50,8 @@ class Score_Shortcode_Test extends WP_UnitTestCase {
 
         $output = do_shortcode( '[feedback_score question="Q1" post_id="2"][feedback_score question="Q2" post_id="2"]' );
 
-        $this->assertStringContainsString( '5.0', $output );
-        $this->assertStringContainsString( '1.0', $output );
+        $this->assertStringContainsString( '5.0/5', $output );
+        $this->assertStringContainsString( '1.0/5', $output );
     }
 }
 


### PR DESCRIPTION
## Summary
- bump plugin version to 1.3.5
- equalize padding inside the score box
- show the score as `x/5`
- update tests and README

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6843a5e205bc83258b54ac553297f0ed