### PR TITLE
Add voting cookie option and split admin pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin adds a simple voting system with optional feedback field. PHPUnit tests require the WordPress testing framework.
 
-Since version 1.3.2 you can customize button labels and the border radius for the feedback and score boxes. Version 1.3.1 allowed multiple `[feedback_score]` shortcodes on one page. The shortcode was introduced in 1.3.0. Version 1.2.11 added configurable box width and improved dark mode labels. Version 1.3.3 introduced layout options for the score box including alignment and text wrapping. Version 1.3.4 added padding inside the score box and centered the text. The latest update ensures consistent spacing on all sides and shows the score as "x/5".
+Since version 1.3.2 you can customize button labels and the border radius for the feedback and score boxes. Version 1.3.1 allowed multiple `[feedback_score]` shortcodes on one page. The shortcode was introduced in 1.3.0. Version 1.2.11 added configurable box width and improved dark mode labels. Version 1.3.3 introduced layout options for the score box including alignment and text wrapping. Version 1.3.4 added padding inside the score box and centered the text. Version 1.4.0 splits the admin area into analysis and settings pages and optionally blocks repeat votes for 24 hours using a cookie.
 
 ## Installing the WordPress testing framework
 

--- a/feedback-voting.php
+++ b/feedback-voting.php
@@ -3,7 +3,7 @@
 Plugin Name: Feedback Voting
 Plugin URI:  https://vogel-webmarketing.de/feedback-voting/
 Description: Bietet ein einfaches "War diese Antwort hilfreich?" (Ja/Nein) Feedback-Voting
-Version:     1.3.5
+Version:     1.4.0
 Author:      Matthes Vogel
 Text Domain: feedback-voting
 */
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('FEEDBACK_VOTING_VERSION', '1.3.5');
+define('FEEDBACK_VOTING_VERSION', '1.4.0');
 define('FEEDBACK_VOTING_DB_VERSION', '1.0.1');
 define('FEEDBACK_VOTING_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('FEEDBACK_VOTING_PLUGIN_URL', plugin_dir_url(__FILE__));
@@ -84,6 +84,7 @@ function feedback_voting_enqueue_scripts() {
     wp_localize_script('feedback-voting-script', 'feedbackVoting', array(
         'ajaxUrl'             => admin_url('admin-ajax.php'),
         'enableFeedbackField' => get_option('feedback_voting_enable_feedback_field', '1'),
+        'preventMultiple'    => get_option('feedback_voting_prevent_multiple', '0'),
         'nonce'               => wp_create_nonce('feedback_nonce_action'),
     ));
 }


### PR DESCRIPTION
## Summary
- bump version to 1.4.0
- split the admin area into analysis and settings pages
- add option to prevent multiple votes for 24h via cookie
- expose the option to JS and implement cookie logic
- document the new feature

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6843a8a4e3888325afec93d8f5aaeb9f