### PR TITLE
Add optional rating schema and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin adds a simple voting system with optional feedback field. PHPUnit tests require the WordPress testing framework.
 
-Since version 1.3.2 you can customize button labels and the border radius for the feedback and score boxes. Version 1.3.1 allowed multiple `[feedback_score]` shortcodes on one page. The shortcode was introduced in 1.3.0. Version 1.2.11 added configurable box width and improved dark mode labels. Version 1.3.3 introduced layout options for the score box including alignment and text wrapping. Version 1.3.4 added padding inside the score box and centered the text. Version 1.4.0 splits the admin area into analysis and settings pages and optionally blocks repeat votes for 24 hours using a cookie.
+Since version 1.3.2 you can customize button labels and the border radius for the feedback and score boxes. Version 1.3.1 allowed multiple `[feedback_score]` shortcodes on one page. The shortcode was introduced in 1.3.0. Version 1.2.11 added configurable box width and improved dark mode labels. Version 1.3.3 introduced layout options for the score box including alignment and text wrapping. Version 1.3.4 added padding inside the score box and centered the text. Version 1.4.0 splits the admin area into analysis and settings pages and optionally blocks repeat votes for 24 hours using a cookie. Version 1.5.0 adds optional star rating schema for Google search results.
 
 ## Installing the WordPress testing framework
 

--- a/admin/class-my-feedback-plugin-admin.php
+++ b/admin/class-my-feedback-plugin-admin.php
@@ -76,6 +76,11 @@ class My_Feedback_Plugin_Admin {
             'sanitize_callback' => 'absint',
             'default'           => 0,
         ));
+        register_setting('feedback_voting_settings_group', 'feedback_voting_schema_rating', array(
+            'type'              => 'boolean',
+            'sanitize_callback' => 'absint',
+            'default'           => 0,
+        ));
         register_setting('feedback_voting_settings_group', 'feedback_voting_primary_color', array(
             'type'              => 'string',
             'sanitize_callback' => 'sanitize_hex_color',
@@ -182,6 +187,13 @@ class My_Feedback_Plugin_Admin {
             'feedback_voting_prevent_multiple',
             __('Mehrfach-Votes innerhalb 24h verhindern?', 'feedback-voting'),
             array($this, 'prevent_multiple_render'),
+            'feedback_voting_settings',
+            'feedback_voting_general_section'
+        );
+        add_settings_field(
+            'feedback_voting_schema_rating',
+            __('Score als Sterne-Markup ausgeben?', 'feedback-voting'),
+            array($this, 'schema_rating_render'),
             'feedback_voting_settings',
             'feedback_voting_general_section'
         );
@@ -325,6 +337,17 @@ class My_Feedback_Plugin_Admin {
         <label for="feedback_voting_prevent_multiple">
             <input type="checkbox" id="feedback_voting_prevent_multiple" name="feedback_voting_prevent_multiple" value="1" <?php checked($value, 1); ?> />
             <?php _e('Per Cookie verhindern, dass innerhalb von 24h mehrfach abgestimmt wird.', 'feedback-voting'); ?>
+        </label>
+        <?php
+    }
+
+    /** Render checkbox for rating schema */
+    public function schema_rating_render() {
+        $value = get_option('feedback_voting_schema_rating', 0);
+        ?>
+        <label for="feedback_voting_schema_rating">
+            <input type="checkbox" id="feedback_voting_schema_rating" name="feedback_voting_schema_rating" value="1" <?php checked($value, 1); ?> />
+            <?php _e('Score als Sterne-Bewertung für Google ausgeben', 'feedback-voting'); ?>
         </label>
         <?php
     }

--- a/includes/class-my-feedback-plugin-shortcode.php
+++ b/includes/class-my-feedback-plugin-shortcode.php
@@ -113,6 +113,10 @@ class My_Feedback_Plugin_Shortcode {
 
         $score = $total > 0 ? ($yes * 5 + $no) / $total : 0;
 
+        if ( get_option( 'feedback_voting_schema_rating', 0 ) && $total > 0 ) {
+            feedback_voting_track_schema( $score, $total );
+        }
+
         $label     = get_option('feedback_voting_score_label', __('Euer Score', 'feedback-voting'));
         $alignment = get_option('feedback_voting_score_alignment', 'left');
         $wrap      = get_option('feedback_voting_score_wrap', 'none');


### PR DESCRIPTION
## Summary
- bump plugin version to 1.5.0
- implement optional schema.org star rating markup
- expose new setting in admin area
- document new feature in README

## Testing
- `phpunit -c phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6843ae93816483259e0b911dd27b26af