### PR TITLE
Add exportable bar chart and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin adds a simple voting system with optional feedback field. PHPUnit tests require the WordPress testing framework.
 
-Since version 1.3.2 you can customize button labels and the border radius for the feedback and score boxes. Version 1.3.1 allowed multiple `[feedback_score]` shortcodes on one page. The shortcode was introduced in 1.3.0. Version 1.2.11 added configurable box width and improved dark mode labels. Version 1.3.3 introduced layout options for the score box including alignment and text wrapping. Version 1.3.4 added padding inside the score box and centered the text. Version 1.4.0 splits the admin area into analysis and settings pages and optionally blocks repeat votes for 24 hours using a cookie. Version 1.5.0 adds optional star rating schema for Google search results.
+Since version 1.3.2 you can customize button labels and the border radius for the feedback and score boxes. Version 1.3.1 allowed multiple `[feedback_score]` shortcodes on one page. The shortcode was introduced in 1.3.0. Version 1.2.11 added configurable box width and improved dark mode labels. Version 1.3.3 introduced layout options for the score box including alignment and text wrapping. Version 1.3.4 added padding inside the score box and centered the text. Version 1.4.0 splits the admin area into analysis and settings pages and optionally blocks repeat votes for 24 hours using a cookie. Version 1.5.0 adds optional star rating schema for Google search results. Version 1.6.0 introduces a PNG-exportable bar chart of the ten most common feedbacks by post.
 
 ## Installing the WordPress testing framework
 

--- a/admin/js/feedback-chart.js
+++ b/admin/js/feedback-chart.js
@@ -1,0 +1,43 @@
+jQuery(function($){
+    if (typeof feedbackChartData === 'undefined') {
+        return;
+    }
+    var ctx = document.getElementById('feedback-chart-canvas');
+    if (!ctx) {
+        return;
+    }
+    var chart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels: feedbackChartData.labels,
+            datasets: [
+                {
+                    label: 'Ja',
+                    data: feedbackChartData.yes,
+                    backgroundColor: '#4CAF50'
+                },
+                {
+                    label: 'Nein',
+                    data: feedbackChartData.no,
+                    backgroundColor: '#F44336'
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            scales: {
+                x: { stacked: true },
+                y: { beginAtZero: true, stacked: true }
+            }
+        }
+    });
+
+    $('#download-chart').on('click', function(e){
+        e.preventDefault();
+        var url = chart.toBase64Image();
+        var link = document.createElement('a');
+        link.href = url;
+        link.download = 'feedback-chart.png';
+        link.click();
+    });
+});

--- a/feedback-voting.php
+++ b/feedback-voting.php
@@ -3,7 +3,7 @@
 Plugin Name: Feedback Voting
 Plugin URI:  https://vogel-webmarketing.de/feedback-voting/
 Description: Bietet ein einfaches "War diese Antwort hilfreich?" (Ja/Nein) Feedback-Voting
-Version:     1.5.0
+Version:     1.6.0
 Author:      Matthes Vogel
 Text Domain: feedback-voting
 */
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('FEEDBACK_VOTING_VERSION', '1.5.0');
+define('FEEDBACK_VOTING_VERSION', '1.6.0');
 define('FEEDBACK_VOTING_DB_VERSION', '1.0.1');
 define('FEEDBACK_VOTING_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('FEEDBACK_VOTING_PLUGIN_URL', plugin_dir_url(__FILE__));


### PR DESCRIPTION
## Summary
- bump plugin version to 1.6.0
- load Chart.js and new script in admin
- show bar chart with export button in analysis page
- include post ID column in top questions table
- document new feature

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6843b59ff34c8325ac6fd38e97d8ceea