### PR TITLE
Add schema rating test

### DIFF
--- a/feedback-voting.php
+++ b/feedback-voting.php
@@ -104,12 +104,16 @@ $myUpdateChecker->setBranch('main');
 
 // Helper for optional rating schema
 global $feedback_voting_schema;
-$feedback_voting_schema = array('score' => 0, 'count' => 0);
+$feedback_voting_schema = array('score' => 0, 'count' => 0, 'name' => '');
 
-function feedback_voting_track_schema($score, $count) {
+function feedback_voting_track_schema($score, $count, $name = '') {
     global $feedback_voting_schema;
     if ($score > $feedback_voting_schema['score']) {
-        $feedback_voting_schema = array('score' => $score, 'count' => $count);
+        $feedback_voting_schema = array(
+            'score' => $score,
+            'count' => $count,
+            'name'  => $name,
+        );
     }
 }
 
@@ -124,6 +128,7 @@ function feedback_voting_output_schema() {
     $data = array(
         '@context' => 'https://schema.org',
         '@type' => 'Article',
+        'name' => $feedback_voting_schema['name'],
         'aggregateRating' => array(
             '@type' => 'AggregateRating',
             'ratingValue' => number_format($feedback_voting_schema['score'], 1),

--- a/includes/class-my-feedback-plugin-shortcode.php
+++ b/includes/class-my-feedback-plugin-shortcode.php
@@ -114,7 +114,8 @@ class My_Feedback_Plugin_Shortcode {
         $score = $total > 0 ? ($yes * 5 + $no) / $total : 0;
 
         if ( get_option( 'feedback_voting_schema_rating', 0 ) && $total > 0 ) {
-            feedback_voting_track_schema( $score, $total );
+            $title = get_the_title( $post_id );
+            feedback_voting_track_schema( $score, $total, $title );
         }
 
         $label     = get_option('feedback_voting_score_label', __('Euer Score', 'feedback-voting'));

--- a/tests/SchemaOutputTest.php
+++ b/tests/SchemaOutputTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Tests for rating schema output in the footer.
+ */
+class Schema_Output_Test extends WP_UnitTestCase {
+    public function test_footer_contains_rating_schema() {
+        global $wpdb;
+
+        update_option( 'feedback_voting_schema_rating', 1 );
+
+        $post_id = self::factory()->post->create( [ 'post_title' => 'My Test Post' ] );
+        $table   = $wpdb->prefix . 'feedback_votes';
+        $now     = current_time( 'mysql' );
+
+        $wpdb->insert( $table, [
+            'question'      => 'Q',
+            'vote'          => 'yes',
+            'feedback_text' => '',
+            'post_id'       => $post_id,
+            'created_at'    => $now,
+        ] );
+        $wpdb->insert( $table, [
+            'question'      => 'Q',
+            'vote'          => 'no',
+            'feedback_text' => '',
+            'post_id'       => $post_id,
+            'created_at'    => $now,
+        ] );
+
+        do_shortcode( "[feedback_score question=\"Q\" post_id=\"$post_id\"]" );
+
+        wp_enqueue_block_template_skip_link();
+        ob_start();
+        do_action( 'wp_footer' );
+        $output = ob_get_clean();
+
+        $this->assertNotEmpty( $output );
+        preg_match( '/<script type="application\/ld\+json">(.*?)<\/script>/s', $output, $m );
+        $this->assertNotEmpty( $m );
+
+        $schema = json_decode( $m[1], true );
+        $this->assertSame( 'My Test Post', $schema['name'] );
+        $this->assertSame( '3.0', $schema['aggregateRating']['ratingValue'] );
+        $this->assertSame( 2, $schema['aggregateRating']['ratingCount'] );
+    }
+}


### PR DESCRIPTION
## Summary
- include page title in rating schema output
- pass name when tracking schema data
- test footer JSON-LD output for name and rating fields

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_684687a5857483258dd92df88bd683c2