### PR TITLE
Remove global snippet settings

### DIFF
--- a/admin/class-my-feedback-plugin-admin.php
+++ b/admin/class-my-feedback-plugin-admin.php
@@ -106,16 +106,6 @@ class My_Feedback_Plugin_Admin {
             'sanitize_callback' => 'absint',
             'default'           => 0,
         ));
-        register_setting('feedback_voting_settings_group', 'feedback_voting_schema_rating', array(
-            'type'              => 'boolean',
-            'sanitize_callback' => 'absint',
-            'default'           => 0,
-        ));
-        register_setting('feedback_voting_settings_group', 'feedback_voting_schema_type', array(
-            'type'              => 'string',
-            'sanitize_callback' => 'sanitize_text_field',
-            'default'           => 'Product',
-        ));
         register_setting('feedback_voting_settings_group', 'feedback_voting_primary_color', array(
             'type'              => 'string',
             'sanitize_callback' => 'sanitize_hex_color',
@@ -252,20 +242,6 @@ class My_Feedback_Plugin_Admin {
             'feedback_voting_prevent_multiple',
             __('Mehrfach-Votes innerhalb 24h verhindern?', 'feedback-voting'),
             array($this, 'prevent_multiple_render'),
-            'feedback_voting_settings',
-            'feedback_voting_general_section'
-        );
-        add_settings_field(
-            'feedback_voting_schema_rating',
-            __('Score als Sterne-Markup ausgeben?', 'feedback-voting'),
-            array($this, 'schema_rating_render'),
-            'feedback_voting_settings',
-            'feedback_voting_general_section'
-        );
-        add_settings_field(
-            'feedback_voting_schema_type',
-            __('Schema-Typ für Bewertungen', 'feedback-voting'),
-            array($this, 'schema_type_render'),
             'feedback_voting_settings',
             'feedback_voting_general_section'
         );
@@ -460,33 +436,6 @@ class My_Feedback_Plugin_Admin {
         <?php
     }
 
-    /** Render checkbox for rating schema */
-    public function schema_rating_render() {
-        $value = get_option('feedback_voting_schema_rating', 0);
-        ?>
-        <label for="feedback_voting_schema_rating">
-            <input type="checkbox" id="feedback_voting_schema_rating" name="feedback_voting_schema_rating" value="1" <?php checked($value, 1); ?> />
-            <?php _e('Score als Sterne-Bewertung für Google ausgeben', 'feedback-voting'); ?>
-        </label>
-        <?php
-    }
-
-    /** Render select for schema type */
-    public function schema_type_render() {
-        $value = get_option('feedback_voting_schema_type', 'Product');
-        ?>
-        <select id="feedback_voting_schema_type" name="feedback_voting_schema_type">
-            <option value="Book" <?php selected($value, 'Book'); ?>>Book</option>
-            <option value="Course" <?php selected($value, 'Course'); ?>>Course</option>
-            <option value="Event" <?php selected($value, 'Event'); ?>>Event</option>
-            <option value="LocalBusiness" <?php selected($value, 'LocalBusiness'); ?>>LocalBusiness</option>
-            <option value="Movie" <?php selected($value, 'Movie'); ?>>Movie</option>
-            <option value="Product" <?php selected($value, 'Product'); ?>>Product</option>
-            <option value="Recipe" <?php selected($value, 'Recipe'); ?>>Recipe</option>
-            <option value="SoftwareApplication" <?php selected($value, 'SoftwareApplication'); ?>>SoftwareApplication</option>
-        </select>
-        <?php
-    }
 
     /** Render Color-Picker-Felder */
     public function color_field_render($args) {
@@ -907,26 +856,9 @@ class My_Feedback_Plugin_Admin {
 
     /** Render the meta box */
     public function render_meta_box($post) {
-        $type        = get_post_meta($post->ID, '_feedback_voting_schema_type', true);
-        $disable     = get_post_meta($post->ID, '_feedback_voting_disable_snippets', true);
         $disable_auto = get_post_meta($post->ID, '_feedback_voting_disable_auto', true);
-        $allowed = array('Book','Course','Event','LocalBusiness','Movie','Product','Recipe','SoftwareApplication');
         wp_nonce_field('feedback_voting_meta_box', 'feedback_voting_meta_box_nonce');
         ?>
-        <p>
-            <label for="feedback_voting_schema_type"><strong><?php _e('Schema-Typ', 'feedback-voting'); ?></strong></label><br />
-            <select id="feedback_voting_schema_type" name="feedback_voting_schema_type">
-                <?php foreach ($allowed as $opt) : ?>
-                    <option value="<?php echo esc_attr($opt); ?>" <?php selected($type ?: get_option('feedback_voting_schema_type', 'Product'), $opt); ?>><?php echo esc_html($opt); ?></option>
-                <?php endforeach; ?>
-            </select>
-        </p>
-        <p>
-            <label>
-                <input type="checkbox" name="feedback_voting_disable_snippets" value="1" <?php checked($disable, '1'); ?> />
-                <?php _e('Bewertungs-Snippets für diesen Beitrag deaktivieren', 'feedback-voting'); ?>
-            </label>
-        </p>
         <p>
             <label>
                 <input type="checkbox" name="feedback_voting_disable_auto" value="1" <?php checked($disable_auto, '1'); ?> />
@@ -947,18 +879,6 @@ class My_Feedback_Plugin_Admin {
         if (!current_user_can('edit_post', $post_id)) {
             return;
         }
-
-        $allowed = array('Book','Course','Event','LocalBusiness','Movie','Product','Recipe','SoftwareApplication');
-        if (isset($_POST['feedback_voting_schema_type'])) {
-            $type = sanitize_text_field($_POST['feedback_voting_schema_type']);
-            if (!in_array($type, $allowed, true)) {
-                $type = get_option('feedback_voting_schema_type', 'Product');
-            }
-            update_post_meta($post_id, '_feedback_voting_schema_type', $type);
-        }
-
-        $disable = isset($_POST['feedback_voting_disable_snippets']) ? '1' : '0';
-        update_post_meta($post_id, '_feedback_voting_disable_snippets', $disable);
 
         $disable_auto = isset($_POST['feedback_voting_disable_auto']) ? '1' : '0';
         update_post_meta($post_id, '_feedback_voting_disable_auto', $disable_auto);

--- a/feedback-voting.php
+++ b/feedback-voting.php
@@ -3,7 +3,7 @@
 Plugin Name: Feedback Voting
 Plugin URI:  https://vogel-webmarketing.de/feedback-voting/
 Description: Bietet ein einfaches "War diese Antwort hilfreich?" (Ja/Nein) Feedback-Voting
-Version:     1.12.0
+Version:     1.13.0
 Author:      Matthes Vogel
 Text Domain: feedback-voting
 */
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('FEEDBACK_VOTING_VERSION', '1.12.0');
+define('FEEDBACK_VOTING_VERSION', '1.13.0');
 define('FEEDBACK_VOTING_DB_VERSION', '1.0.1');
 define('FEEDBACK_VOTING_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('FEEDBACK_VOTING_PLUGIN_URL', plugin_dir_url(__FILE__));
@@ -110,25 +110,10 @@ global $feedback_voting_schema;
 $feedback_voting_schema = array('score' => 0, 'count' => 0, 'name' => '', 'type' => '');
 
 function feedback_voting_get_schema_type($post_id = 0) {
-    if (!$post_id && is_singular()) {
-        $post_id = get_the_ID();
-    }
-    if ($post_id) {
-        $type = get_post_meta($post_id, '_feedback_voting_schema_type', true);
-        if (!empty($type)) {
-            return $type;
-        }
-    }
-    return get_option('feedback_voting_schema_type', 'Product');
+    return 'Product';
 }
 
 function feedback_voting_schema_disabled($post_id = 0) {
-    if (!$post_id && is_singular()) {
-        $post_id = get_the_ID();
-    }
-    if ($post_id) {
-        return (bool) get_post_meta($post_id, '_feedback_voting_disable_snippets', true);
-    }
     return false;
 }
 
@@ -148,17 +133,11 @@ function feedback_voting_track_schema($score, $count, $name = '', $type = null) 
 }
 
 function feedback_voting_output_schema() {
-    if (!get_option('feedback_voting_schema_rating', 0)) {
-        return;
-    }
     global $feedback_voting_schema;
     if (empty($feedback_voting_schema) || $feedback_voting_schema['score'] <= 0) {
         return;
     }
     $post_id = is_singular() ? get_the_ID() : 0;
-    if ($post_id && feedback_voting_schema_disabled($post_id)) {
-        return;
-    }
 
     $type = !empty($feedback_voting_schema['type']) ? $feedback_voting_schema['type'] : feedback_voting_get_schema_type($post_id);
     $data = array(
@@ -209,7 +188,7 @@ function feedback_voting_auto_append($content) {
     $shortcode  = '[feedback_voting question="' . esc_attr($question) . '"]';
     $post_id       = get_the_ID();
     $schema_type   = feedback_voting_get_schema_type($post_id);
-    $schema_rating = feedback_voting_schema_disabled($post_id) ? 0 : get_option('feedback_voting_schema_rating', 0);
+    $schema_rating = 0;
 
     if (get_option('feedback_voting_auto_score', 0)) {
         $shortcode .= ' [feedback_score question="' . esc_attr($question) . '" post_id="' . $post_id . '" schema_type="' . esc_attr($schema_type) . '" schema_rating="' . esc_attr($schema_rating) . '"]';

--- a/includes/class-my-feedback-plugin-shortcode.php
+++ b/includes/class-my-feedback-plugin-shortcode.php
@@ -97,8 +97,8 @@ class My_Feedback_Plugin_Shortcode {
             'label_position'  => '',
         ), $atts, 'feedback_score');
 
-        $atts['schema_type'] = $atts['schema_type'] !== '' ? $atts['schema_type'] : feedback_voting_get_schema_type($atts['post_id']);
-        $atts['schema_rating'] = $atts['schema_rating'] !== '' ? $atts['schema_rating'] : ( feedback_voting_schema_disabled($atts['post_id']) ? 0 : get_option('feedback_voting_schema_rating', 0) );
+        $atts['schema_type']   = $atts['schema_type'] !== '' ? $atts['schema_type'] : feedback_voting_get_schema_type($atts['post_id']);
+        $atts['schema_rating'] = $atts['schema_rating'] !== '' ? $atts['schema_rating'] : 0;
 
         $question = $atts['question'];
         $post_id  = intval($atts['post_id']);

--- a/tests/SchemaOutputTest.php
+++ b/tests/SchemaOutputTest.php
@@ -6,8 +6,6 @@ class Schema_Output_Test extends WP_UnitTestCase {
     public function test_footer_contains_rating_schema() {
         global $wpdb;
 
-        update_option( 'feedback_voting_schema_rating', 1 );
-
         global $feedback_voting_schema;
         $feedback_voting_schema = [ 'score' => 0, 'count' => 0, 'name' => '', 'type' => '' ];
 
@@ -53,8 +51,6 @@ class Schema_Output_Test extends WP_UnitTestCase {
     public function test_schema_type_override() {
         global $wpdb;
 
-        update_option( 'feedback_voting_schema_rating', 1 );
-
         $post_id = self::factory()->post->create( [ 'post_title' => 'My Recipe' ] );
         $this->go_to( get_permalink( $post_id ) );
         $table   = $wpdb->prefix . 'feedback_votes';
@@ -68,7 +64,7 @@ class Schema_Output_Test extends WP_UnitTestCase {
             'created_at'    => $now,
         ] );
 
-        do_shortcode( "[feedback_score question=\"Q\" post_id=\"$post_id\" schema_type=\"Recipe\"]" );
+        do_shortcode( "[feedback_score question=\"Q\" post_id=\"$post_id\" schema_type=\"Recipe\" schema_rating=\"1\"]" );
 
         wp_enqueue_block_template_skip_link();
         ob_start();
@@ -83,8 +79,6 @@ class Schema_Output_Test extends WP_UnitTestCase {
 
     public function test_schema_disabled_via_attribute() {
         global $wpdb;
-
-        update_option( 'feedback_voting_schema_rating', 1 );
 
         $post_id = self::factory()->post->create( [ 'post_title' => 'No Schema' ] );
         $this->go_to( get_permalink( $post_id ) );
@@ -113,34 +107,4 @@ class Schema_Output_Test extends WP_UnitTestCase {
         $this->assertEmpty( $m );
     }
 
-    public function test_schema_disabled_via_post_meta() {
-        global $wpdb;
-
-        update_option( 'feedback_voting_schema_rating', 1 );
-
-        $post_id = self::factory()->post->create( [ 'post_title' => 'Meta Off' ] );
-        $this->go_to( get_permalink( $post_id ) );
-        update_post_meta( $post_id, '_feedback_voting_disable_snippets', 1 );
-
-        $table   = $wpdb->prefix . 'feedback_votes';
-        $now     = current_time( 'mysql' );
-
-        $wpdb->insert( $table, [
-            'question'      => 'Q',
-            'vote'          => 'yes',
-            'feedback_text' => '',
-            'post_id'       => $post_id,
-            'created_at'    => $now,
-        ] );
-
-        do_shortcode( "[feedback_score question=\"Q\" post_id=\"$post_id\"]" );
-
-        wp_enqueue_block_template_skip_link();
-        ob_start();
-        do_action( 'wp_footer' );
-        $output = ob_get_clean();
-
-        preg_match( '/<script type="application\/ld\+json">(.*?)<\/script>/s', $output, $m );
-        $this->assertEmpty( $m );
-    }
 }


### PR DESCRIPTION
## Summary
- bump plugin version
- drop global schema options and meta box for snippets
- default snippet settings per module only
- update tests

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6846cf63da308325b3d7e3cdc9a6f2bc