### PR TITLE
Fix admin hook registration with singleton pattern

### DIFF
--- a/admin/class-my-feedback-plugin-admin.php
+++ b/admin/class-my-feedback-plugin-admin.php
@@ -5,6 +5,19 @@ if (!defined('ABSPATH')) {
 
 class My_Feedback_Plugin_Admin {
 
+    /** Singleton instance */
+    private static $instance = null;
+
+    /**
+     * Retrieve the singleton instance.
+     */
+    public static function get_instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
     public function __construct() {
         // Admin-Menüs und -Einstellungen
         add_action('admin_menu', array($this, 'register_admin_menu'));
@@ -987,8 +1000,9 @@ class My_Feedback_Plugin_Admin {
             $(document).on('change', '#feedback_voting_schema_type', toggleLbFields);
             toggleLbFields();
             switchTab($('.fv-meta-tabs .nav-tab-active').data('fv-tab'));
-        });
-        </script>
+});
+</script>
+<?php
     }
 
     /** Save meta box values */

--- a/feedback-voting.php
+++ b/feedback-voting.php
@@ -29,7 +29,7 @@ register_deactivation_hook(__FILE__, array('My_Feedback_Plugin_DB_Manager', 'dea
 function feedback_voting_init() {
     load_plugin_textdomain('feedback-voting', false, dirname(plugin_basename(__FILE__)) . '/languages');
     My_Feedback_Plugin_DB_Manager::maybe_update_db();
-    new My_Feedback_Plugin_Admin();
+    My_Feedback_Plugin_Admin::get_instance();
     new My_Feedback_Plugin_Shortcode();
     new My_Feedback_Plugin_Ajax();
     new My_Feedback_Plugin_Block();


### PR DESCRIPTION
## Summary
- add singleton pattern for admin class
- register admin instance via `get_instance()`
- restore missing PHP section delimiter in admin file

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_684bdb8ae7ec83259e54c92d5e4da7a3