### PR TITLE
Add page URL tracking for feedback entries

### DIFF
--- a/admin/class-my-feedback-plugin-admin.php
+++ b/admin/class-my-feedback-plugin-admin.php
@@ -783,6 +783,7 @@ class My_Feedback_Plugin_Admin {
                         <th><?php _e('Vote', 'feedback-voting'); ?></th>
                         <th><?php _e('Feedback-Text', 'feedback-voting'); ?></th>
                         <th><?php _e('Shortcode-Location', 'feedback-voting'); ?></th>
+                        <th><?php _e('URL', 'feedback-voting'); ?></th>
                         <th><?php _e('Post ID', 'feedback-voting'); ?></th>
                         <th><?php _e('Aktion', 'feedback-voting'); ?></th>
                     </tr>
@@ -808,12 +809,17 @@ class My_Feedback_Plugin_Admin {
                                     <em><?php echo esc_html($post_title); ?></em>
                                 <?php endif; ?>
                             </td>
+                            <td>
+                                <?php if (!empty($feedback->page_url)) : ?>
+                                    <a href="<?php echo esc_url($feedback->page_url); ?>" target="_blank"><?php echo esc_html($feedback->page_url); ?></a>
+                                <?php endif; ?>
+                            </td>
                             <td><?php echo intval($feedback->post_id); ?></td>
                             <td><button type="button" class="button feedback-copy-button"><?php _e('Kopieren', 'feedback-voting'); ?></button></td>
                         </tr>
                     <?php endforeach; ?>
                 <?php else : ?>
-                    <tr><td colspan="7"><?php _e('Keine Feedbacks vorhanden.', 'feedback-voting'); ?></td></tr>
+                    <tr><td colspan="8"><?php _e('Keine Feedbacks vorhanden.', 'feedback-voting'); ?></td></tr>
                 <?php endif; ?>
                 </tbody>
             </table>
@@ -1058,6 +1064,7 @@ class My_Feedback_Plugin_Admin {
             __('Vote', 'feedback-voting'),
             __('Feedback-Text', 'feedback-voting'),
             __('Shortcode-Location', 'feedback-voting'),
+            __('URL', 'feedback-voting'),
             __('Post ID', 'feedback-voting'),
         );
         $columns_1252 = array_map(function($col) {
@@ -1077,6 +1084,7 @@ class My_Feedback_Plugin_Admin {
                 $r->vote,
                 $r->feedback_text,
                 $post_title,
+                $r->page_url,
                 $r->post_id
             );
             $line_1252 = array_map(function($val) {

--- a/feedback-voting.php
+++ b/feedback-voting.php
@@ -3,7 +3,7 @@
 Plugin Name: Feedback Voting
 Plugin URI:  https://vogel-webmarketing.de/feedback-voting/
 Description: Bietet ein einfaches "War diese Antwort hilfreich?" (Ja/Nein) Feedback-Voting
-Version:     1.16.3
+Version:     1.16.4
 Author:      Matthes Vogel
 Text Domain: feedback-voting
 */
@@ -12,8 +12,8 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('FEEDBACK_VOTING_VERSION', '1.16.3');
-define('FEEDBACK_VOTING_DB_VERSION', '1.0.1');
+define('FEEDBACK_VOTING_VERSION', '1.16.4');
+define('FEEDBACK_VOTING_DB_VERSION', '1.0.2');
 define('FEEDBACK_VOTING_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('FEEDBACK_VOTING_PLUGIN_URL', plugin_dir_url(__FILE__));
 

--- a/includes/class-my-feedback-plugin-ajax.php
+++ b/includes/class-my-feedback-plugin-ajax.php
@@ -31,6 +31,7 @@ class My_Feedback_Plugin_Ajax {
         $vote     = isset($_POST['vote']) ? sanitize_text_field($_POST['vote']) : '';
         $feedback = isset($_POST['feedback']) ? sanitize_textarea_field($_POST['feedback']) : '';
         $post_id  = isset($_POST['post_id']) ? intval($_POST['post_id']) : 0;
+        $page_url = isset($_POST['page_url']) ? esc_url_raw($_POST['page_url']) : '';
 
         // Beim allerersten Insert benötigen wir mindestens eine Frage und einen Vote.
         // Beim Update könnte es sein, dass wir (strikt genommen) vote/frage nicht mehr benötigen,
@@ -48,10 +49,11 @@ class My_Feedback_Plugin_Ajax {
                 'vote'          => $vote,
                 'feedback_text' => $feedback, // kann hier leer sein
                 'post_id'       => $post_id,
+                'page_url'      => $page_url,
                 'created_at'    => current_time('mysql')
             );
 
-            $format = array('%s','%s','%s','%d','%s');
+            $format = array('%s','%s','%s','%d','%s','%s');
 
             $result = $wpdb->insert($table_name, $data, $format);
 

--- a/includes/class-my-feedback-plugin-db-manager.php
+++ b/includes/class-my-feedback-plugin-db-manager.php
@@ -25,6 +25,7 @@ class My_Feedback_Plugin_DB_Manager {
             vote VARCHAR(10) NOT NULL,
             feedback_text TEXT NULL,
             post_id BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+            page_url TEXT NOT NULL,
             created_at DATETIME NOT NULL,
             PRIMARY KEY (id)
         ) $charset_collate;";

--- a/js/script.js
+++ b/js/script.js
@@ -53,6 +53,7 @@ jQuery(function($) {
                 'yes',
                 '',
                 postId,
+                window.location.href,
                 function onSuccess() {
                     if (preventMultiple) {
                         setCookie(cookieName, '1', 24);
@@ -78,6 +79,7 @@ jQuery(function($) {
                 'no',
                 '',
                 postId,
+                window.location.href,
                 function onSuccess(response) {
                     // Speichern des Vote-ID in container (für späteres Update)
                     if (response.vote_id) {
@@ -130,6 +132,7 @@ jQuery(function($) {
             'no',            // vote bleibt 'no'
             feedbackText,
             postId,
+            window.location.href,
             function onSuccess() {
                 if (preventMultiple) {
                     setCookie(cookieName, '1', 24);
@@ -156,7 +159,7 @@ jQuery(function($) {
      * @param {function} successCallback
      * @param {function} errorCallback
      */
-    function ajaxVote(voteId, question, vote, feedback, postId, successCallback, errorCallback) {
+    function ajaxVote(voteId, question, vote, feedback, postId, pageUrl, successCallback, errorCallback) {
         $.ajax({
             url: feedbackVoting.ajaxUrl,
             method: 'POST',
@@ -167,6 +170,7 @@ jQuery(function($) {
                 vote: vote,
                 feedback: feedback,
                 post_id: postId,
+                page_url: pageUrl,
                 // Nonce:
                 security: feedbackVoting.nonce
             },

--- a/tests/SchemaOutputTest.php
+++ b/tests/SchemaOutputTest.php
@@ -19,6 +19,7 @@ class Schema_Output_Test extends WP_UnitTestCase {
             'vote'          => 'yes',
             'feedback_text' => '',
             'post_id'       => $post_id,
+            'page_url'      => 'http://example.org/post',
             'created_at'    => $now,
         ] );
         $wpdb->insert( $table, [
@@ -26,6 +27,7 @@ class Schema_Output_Test extends WP_UnitTestCase {
             'vote'          => 'no',
             'feedback_text' => '',
             'post_id'       => $post_id,
+            'page_url'      => 'http://example.org/post',
             'created_at'    => $now,
         ] );
 
@@ -61,6 +63,7 @@ class Schema_Output_Test extends WP_UnitTestCase {
             'vote'          => 'yes',
             'feedback_text' => '',
             'post_id'       => $post_id,
+            'page_url'      => 'http://example.org/recipe',
             'created_at'    => $now,
         ] );
 
@@ -94,6 +97,7 @@ class Schema_Output_Test extends WP_UnitTestCase {
             'vote'          => 'yes',
             'feedback_text' => '',
             'post_id'       => $post_id,
+            'page_url'      => 'http://example.org/business',
             'created_at'    => $now,
         ] );
 
@@ -133,6 +137,7 @@ class Schema_Output_Test extends WP_UnitTestCase {
             'vote'          => 'yes',
             'feedback_text' => '',
             'post_id'       => $post_id,
+            'page_url'      => 'http://example.org/shop',
             'created_at'    => $now,
         ] );
 
@@ -164,6 +169,7 @@ class Schema_Output_Test extends WP_UnitTestCase {
             'vote'          => 'yes',
             'feedback_text' => '',
             'post_id'       => $post_id,
+            'page_url'      => 'http://example.org/noschema',
             'created_at'    => $now,
         ] );
 

--- a/tests/ScoreShortcodeTest.php
+++ b/tests/ScoreShortcodeTest.php
@@ -13,6 +13,7 @@ class Score_Shortcode_Test extends WP_UnitTestCase {
             'vote'          => 'yes',
             'feedback_text' => '',
             'post_id'       => 1,
+            'page_url'      => 'http://example.org/1',
             'created_at'    => $now,
         ] );
         $wpdb->insert( $table, [
@@ -20,6 +21,7 @@ class Score_Shortcode_Test extends WP_UnitTestCase {
             'vote'          => 'no',
             'feedback_text' => '',
             'post_id'       => 1,
+            'page_url'      => 'http://example.org/1',
             'created_at'    => $now,
         ] );
 
@@ -37,6 +39,7 @@ class Score_Shortcode_Test extends WP_UnitTestCase {
             'vote'          => 'yes',
             'feedback_text' => '',
             'post_id'       => 2,
+            'page_url'      => 'http://example.org/2',
             'created_at'    => $now,
         ] );
 
@@ -45,6 +48,7 @@ class Score_Shortcode_Test extends WP_UnitTestCase {
             'vote'          => 'no',
             'feedback_text' => '',
             'post_id'       => 2,
+            'page_url'      => 'http://example.org/2',
             'created_at'    => $now,
         ] );
 

--- a/tests/VoteAjaxTest.php
+++ b/tests/VoteAjaxTest.php
@@ -16,6 +16,7 @@ class Vote_Ajax_Test extends WP_Ajax_UnitTestCase {
             'vote'     => 'yes',
             'feedback' => '',
             'post_id'  => 1,
+            'page_url' => 'http://example.org/page',
             'security' => wp_create_nonce( 'feedback_nonce_action' ),
         ];
 
@@ -43,6 +44,7 @@ class Vote_Ajax_Test extends WP_Ajax_UnitTestCase {
             'vote'          => 'no',
             'feedback_text' => '',
             'post_id'       => 2,
+            'page_url'      => 'http://example.org/post',
             'created_at'    => current_time( 'mysql' ),
         ] );
         $vote_id = $wpdb->insert_id;
@@ -50,6 +52,7 @@ class Vote_Ajax_Test extends WP_Ajax_UnitTestCase {
         $_POST = [
             'vote_id'  => $vote_id,
             'feedback' => 'Updated text',
+            'page_url' => 'http://example.org/post',
             'security' => wp_create_nonce( 'feedback_nonce_action' ),
         ];
 


### PR DESCRIPTION
## Summary
- add `page_url` column to store submission address
- capture and store current page URL during voting
- display URL column in admin list and CSV export
- bump plugin and DB version
- update tests for new schema

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686bb6a17b8883258370f3a88a5807ba